### PR TITLE
Refactor ListBucketResult to use Java streams

### DIFF
--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/ListBucketOptions.java
@@ -20,6 +20,8 @@ import com.google.common.base.Objects;
 public final class ListBucketOptions {
   // Default number of MaxKeys when it is not specified
   public static final int DEFAULT_MAX_KEYS = 1000;
+  // Default EncodingType when it is not specified
+  public static final String DEFAULT_ENCODING_TYPE = "url";
 
   private String mMarker;
   private String mPrefix;
@@ -44,18 +46,17 @@ public final class ListBucketOptions {
    * Constructs a new {@link ListBucketOptions}.
    */
   private ListBucketOptions() {
-
     // common parameter
     mPrefix = "";
     mMaxKeys = DEFAULT_MAX_KEYS;
     mDelimiter = null;
-    mEncodingType = "url";
+    mEncodingType = DEFAULT_ENCODING_TYPE;
     // listObject parameter
-    mMarker = "";
+    mMarker = null;
     // listObjectV2 parameter
     mListType = null;
-    mContinuationToken = "";
-    mStartAfter = "";
+    mContinuationToken = null;
+    mStartAfter = null;
   }
 
   /**

--- a/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ErrorCode.java
+++ b/core/server/proxy/src/main/java/alluxio/proxy/s3/S3ErrorCode.java
@@ -26,6 +26,7 @@ public class S3ErrorCode {
     public static final String BUCKET_ALREADY_EXISTS = "BucketAlreadyExists";
     public static final String BUCKET_NOT_EMPTY = "BucketNotEmpty";
     public static final String INTERNAL_ERROR = "InternalError";
+    public static final String INVALID_ARGUMENT = "InvalidArgument";
     public static final String INVALID_BUCKET_NAME = "InvalidBucketName";
     public static final String MALFORMED_XML = "MalformedXML";
     public static final String METADATA_TOO_LARGE = "MetadataTooLarge";
@@ -56,6 +57,10 @@ public class S3ErrorCode {
       Name.BUCKET_NOT_EMPTY,
       "The bucket you tried to delete is not empty",
       Response.Status.CONFLICT);
+  public static final S3ErrorCode INVALID_ARGUMENT = new S3ErrorCode(
+      Name.INVALID_ARGUMENT,
+      "The request was invalid.", // this message should be overridden by the throw-er
+      Response.Status.BAD_REQUEST);
   public static final S3ErrorCode INVALID_BUCKET_NAME = new S3ErrorCode(
       Name.INVALID_BUCKET_NAME,
       "The specified bucket name is invalid",


### PR DESCRIPTION
The original `ListBucketResult` implementation used Java streams, and the base branch this PR is targeting changed it to an iterative for-loop approach. This PR refactors it back to use Java streams (along with some improvements to edge-case handling & code cleanliness).